### PR TITLE
S3 headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ Sync local directory to AWS S3
 
 Options:
   -h, --help                   Print this help info.
-  -s, --source PATH            Set source directory to upload to s3 to PATH.
-  -b, --bucket BUCKET          Set s3 bucket name to BUCKET.
-  -a, --access-key ACCESS_KEY  Set s3 access key to ACCESS_KEY.
-  -k, --secret-key SECRET      Set s3 secret key to SECRET.
-  -o, --options OPTIONS        Conj OPTIONS onto extra option set for each s3 file
+  -s, --source PATH            PATH sets subdirectory in :target-path to upload to s3.
+  -b, --bucket BUCKET          BUCKET sets s3 bucket name.
+  -a, --access-key ACCESS_KEY  ACCESS_KEY sets s3 access key.
+  -k, --secret-key SECRET      SECRET sets s3 secret key.
+  -m, --metadata META          Conj META onto a map with metadata to set on the objects, passed through to clj-aws-s3
+  -p, --permissions PERMS      Conj PERMS onto a seq of 2-tuples of `[grantee permission]`, passed through to clj-aws-s3
 ```
 
 ## Contributions

--- a/src/hashobject/boot_s3.clj
+++ b/src/hashobject/boot_s3.clj
@@ -7,24 +7,22 @@
 
 (def ^:private
   +defaults+ {:source "public"
-              :options {:permissions [[:all-users :read]]}})
+              :permissions [[:all-users :read]]})
 
 (boot/deftask s3-sync
-  "Sync local directory to AWS S3
-
-  The `options` parameter takes a map with two optional keys:
-   - `:metadata` a map with metadata to set on the objects, passed through to clj-aws-s3
-   - `:permissions` a seq of 2-tuples of `[grantee permission]`, passed through to clj-aws-s3"
-  [s source     PATH       str       "subdirectory in :target-path to upload to s3"
-   b bucket     BUCKET     str       "s3 bucket name"
-   a access-key ACCESS_KEY str       "s3 access key"
-   k secret-key SECRET     str       "s3 secret key"
-   o options    OPTIONS    edn       "metadata and permissions to apply to all synced objects"]
+  "Sync local directory to AWS S3"
+  [s source      PATH       str       "subdirectory in :target-path to upload to s3"
+   b bucket      BUCKET     str       "s3 bucket name"
+   a access-key  ACCESS_KEY str       "s3 access key"
+   k secret-key  SECRET     str       "s3 secret key"
+   m metadata    META       {kw str}  "a map with metadata to set on the objects, passed through to clj-aws-s3"
+   p permissions PERMS      [[kw kw]] "a seq of 2-tuples of `[grantee permission]`, passed through to clj-aws-s3"]
   (let [options (merge +defaults+ *opts*)
-        cred    (select-keys options [:access-key :secret-key])]
+        cred    (select-keys options [:access-key :secret-key])
+        s3-opts {:metadata metadata :permissions (:permissions options)}]
     (boot/with-post-wrap fileset
       (let [files (->> (boot/output-files fileset)
                        (boot/by-re [(re-pattern (str "^" (:source options)))]))]
         (u/info "Start upload to AWS S3.\n")
-        (s3/sync-to-s3 cred files (:source options) (:bucket options) (:options options))
+        (s3/sync-to-s3 cred files (:source options) (:bucket options) s3-opts)
         (u/info "Uploaded to AWS S3.\n")))))

--- a/src/hashobject/boot_s3.clj
+++ b/src/hashobject/boot_s3.clj
@@ -7,15 +7,19 @@
 
 (def ^:private
   +defaults+ {:source "public"
-              :options {}})
+              :options {:permissions [[:all-users :read]]}})
 
 (boot/deftask s3-sync
-  "Sync local directory to AWS S3"
+  "Sync local directory to AWS S3
+
+  The `options` parameter takes a map with two optional keys:
+   - `:metadata` a map with metadata to set on the objects, passed through to clj-aws-s3
+   - `:permissions` a seq of 2-tuples of `[grantee permission]`, passed through to clj-aws-s3"
   [s source     PATH       str       "subdirectory in :target-path to upload to s3"
    b bucket     BUCKET     str       "s3 bucket name"
    a access-key ACCESS_KEY str       "s3 access key"
    k secret-key SECRET     str       "s3 secret key"
-   o options    OPTIONS    {str str} "Extra options set for each s3 file"]
+   o options    OPTIONS    edn       "metadata and permissions to apply to all synced objects"]
   (let [options (merge +defaults+ *opts*)
         cred    (select-keys options [:access-key :secret-key])]
     (boot/with-post-wrap fileset

--- a/src/hashobject/boot_s3/core.clj
+++ b/src/hashobject/boot_s3/core.clj
@@ -59,7 +59,7 @@
         (let [{:keys [path tmp-file]} (first deltas)
               {:keys [metadata permissions]} (merge-with merge
                                                          options
-                                                         (:hashobject/boot-s3 (meta tmp-file)))]
+                                                         (:hashobject/boot-s3 tmp-file))]
           (print "  " path "uploading ...")
 
           (s3/put-file

--- a/src/hashobject/boot_s3/core.clj
+++ b/src/hashobject/boot_s3/core.clj
@@ -1,5 +1,6 @@
 (ns hashobject.boot-s3.core
-  (:require [hashobject.boot-s3.fs :as fs]
+  (:require [boot.core :as boot]
+            [hashobject.boot-s3.fs :as fs]
             [hashobject.boot-s3.s3 :as s3]
             [hashobject.boot-s3.merge :as m]))
 
@@ -10,8 +11,6 @@
 (declare print-delta-summary)
 (declare print-sync-complete-message)
 
-(def default-options {:public true})
-
 (defn sync-to-s3
   "Syncronise the local directory 'dir-path' to the S3 bucket 'bucket-name'."
   ([aws-credentials files dir-path bucket-name]
@@ -21,7 +20,7 @@
                      :files files
                      :dir-path dir-path
                      :bucket-name bucket-name
-                     :options (merge default-options options)}]
+                     :options options}]
       (-> sync-state
         (capture-file-details)
         (calculate-deltas)
@@ -57,17 +56,19 @@
   (when (empty? errors)
     (loop [deltas deltas]
       (if (not (empty? deltas))
-        (let [[_ {:keys [path file]}] (first deltas)]
+        (let [{:keys [path tmp-file]} (first deltas)
+              {:keys [metadata permissions]} (merge-with merge
+                                                         options
+                                                         (:hashobject/boot-s3 (meta tmp-file)))]
           (print "  " path "uploading ...")
 
           (s3/put-file
             aws-credentials
             bucket-name
             path
-            file)
-
-          (when (:public options)
-            (s3/make-file-public aws-credentials bucket-name path))
+            (boot/tmp-file tmp-file)
+            metadata
+            permissions)
 
           (println "\r  " path "done." padding)
           (recur (rest deltas))))))

--- a/src/hashobject/boot_s3/fs.clj
+++ b/src/hashobject/boot_s3/fs.clj
@@ -31,6 +31,5 @@
 (defn- path->file-details [root-path tmp-file]
   (let [file-path (:path tmp-file)
         rel-path (relative-path root-path file-path)
-        file (boot/tmp-file tmp-file)
-        md5 (p/md5 file)]
-    {:path rel-path :md5 md5 :file file}))
+        md5 (p/md5 (boot/tmp-file tmp-file))]
+    {:path rel-path :md5 md5 :tmp-file tmp-file}))

--- a/src/hashobject/boot_s3/fs.clj
+++ b/src/hashobject/boot_s3/fs.clj
@@ -6,7 +6,6 @@
 
 (declare relative-path)
 (declare path->file-details)
-(declare path->absolute-path)
 
 (defn analyse-local-files
   "Analyse a local directory returnings a set
@@ -18,9 +17,6 @@
        (remove #(.isDirectory (boot/tmp-file %)))
        (map (partial path->file-details dir-path))
        (set)))
-
-(defn path->absolute-path [path]
-  (.getAbsolutePath (clojure.java.io/file path)))
 
 ;; Private Helper Functions
 

--- a/src/hashobject/boot_s3/fs.clj
+++ b/src/hashobject/boot_s3/fs.clj
@@ -14,9 +14,8 @@
    under the directory."
   [dir-path files]
   (->> files
-       (remove #(.isDirectory (boot/tmp-file %)))
        (map (partial path->file-details dir-path))
-       (set)))
+       set))
 
 ;; Private Helper Functions
 

--- a/src/hashobject/boot_s3/merge.clj
+++ b/src/hashobject/boot_s3/merge.clj
@@ -2,5 +2,7 @@
   (:require [clojure.set :as s]))
 
 (defn generate-deltas [local-file-details s3-file-details]
-  (let [upload-file-details (s/difference local-file-details s3-file-details)]
+  (let [upload-file-details (remove #(contains? s3-file-details
+                                                (select-keys % [:path :md5]))
+                                    local-file-details)]
     (set (map #(vector :upload %) upload-file-details))))

--- a/src/hashobject/boot_s3/merge.clj
+++ b/src/hashobject/boot_s3/merge.clj
@@ -2,7 +2,6 @@
   (:require [clojure.set :as s]))
 
 (defn generate-deltas [local-file-details s3-file-details]
-  (let [upload-file-details (remove #(contains? s3-file-details
-                                                (select-keys % [:path :md5]))
-                                    local-file-details)]
-    (set (map #(vector :upload %) upload-file-details))))
+  (remove #(contains? s3-file-details
+                      (select-keys % [:path :md5]))
+          local-file-details))

--- a/src/hashobject/boot_s3/s3.clj
+++ b/src/hashobject/boot_s3/s3.clj
@@ -31,6 +31,5 @@
   (let [grant (s3/grant :all-users :read)]
     (s3/update-object-acl cred bucket-name key grant)))
 
-(defn put-file [cred bucket-name key file-path]
-  (let [file (clojure.java.io/file file-path)]
-    (s3/put-object cred bucket-name key file)))
+(defn put-file [cred bucket-name key file]
+  (s3/put-object cred bucket-name key file))

--- a/src/hashobject/boot_s3/s3.clj
+++ b/src/hashobject/boot_s3/s3.clj
@@ -27,9 +27,6 @@
            (remove nil?)
            (set)))))
 
-(defn make-file-public [cred bucket-name key]
-  (let [grant (s3/grant :all-users :read)]
-    (s3/update-object-acl cred bucket-name key grant)))
-
-(defn put-file [cred bucket-name key file]
-  (s3/put-object cred bucket-name key file))
+(defn put-file [cred bucket-name key file metadata permissions]
+  (let [grants (map #(apply s3/grant %) permissions)]
+    (apply s3/put-object cred bucket-name key file metadata grants)))


### PR DESCRIPTION
This 	fixes #5, and allows passing metadata and permissions through to clj-aws-s3. It allows bulk control of metadata and permissions through the `options` task parameter, and/or file-level control through boot
metadata, under the `:hashobject/boot-s3`, which should contain a map of metadata and/or permissions in the same shape as the `options` task parameter.

Depends on #6, because this is much easier when working with the fileset.