### PR TITLE
Force upload

### DIFF
--- a/src/hashobject/boot_s3.clj
+++ b/src/hashobject/boot_s3.clj
@@ -15,12 +15,13 @@
    b bucket     BUCKET     str       "s3 bucket name"
    a access-key ACCESS_KEY str       "s3 access key"
    k secret-key SECRET     str       "s3 secret key"
-   o options    OPTIONS    {str str} "Extra options set for each s3 file"]
+   o options    OPTIONS    {str str} "Extra options set for each s3 file"
+   f force                 bool      "Set to `true` to force upload of all objects"]
   (let [options (merge +defaults+ *opts*)
         cred    (select-keys options [:access-key :secret-key])]
     (boot/with-post-wrap fileset
       (let [files (->> (boot/output-files fileset)
                        (boot/by-re [(re-pattern (str "^" (:source options)))]))]
         (u/info "Start upload to AWS S3.\n")
-        (s3/sync-to-s3 cred files (:source options) (:bucket options) (:options options))
+        (s3/sync-to-s3 cred files (:source options) (:bucket options) (:options options) force)
         (u/info "Uploaded to AWS S3.\n")))))

--- a/src/hashobject/boot_s3/core.clj
+++ b/src/hashobject/boot_s3/core.clj
@@ -15,19 +15,24 @@
 (defn sync-to-s3
   "Syncronise the local directory 'dir-path' to the S3 bucket 'bucket-name'."
   ([aws-credentials files dir-path bucket-name]
-   (sync-to-s3 aws-credentials dir-path bucket-name {}))
+   (sync-to-s3 aws-credentials dir-path bucket-name {} false))
   ([aws-credentials files dir-path bucket-name options]
-   (let [sync-state {:aws-credentials aws-credentials
-                     :files files
-                     :dir-path dir-path
-                     :bucket-name bucket-name
-                     :options (merge default-options options)}]
+   (sync-to-s3 aws-credentials dir-path bucket-name options false))
+  ([aws-credentials files dir-path bucket-name options force]
+   (let [sync-state* {:aws-credentials aws-credentials
+                      :files files
+                      :dir-path dir-path
+                      :bucket-name bucket-name
+                      :options (merge default-options options)}
+         sync-state (if force
+                      (assoc sync-state* :deltas (fs/analyse-local-files dir-path files))
+                      (-> sync-state*
+                          capture-file-details
+                          calculate-deltas))]
       (-> sync-state
-        (capture-file-details)
-        (calculate-deltas)
-        (print-delta-summary)
-        (push-deltas-to-s3)
-        (print-sync-complete-message)))))
+          print-delta-summary
+          push-deltas-to-s3
+          print-sync-complete-message))))
 
 ;; Private functions
 


### PR DESCRIPTION
Assuming #7 gets merged, users may find themselves in a situation where they've changed headers or permissions, but `boot-s3` won't upload them because the md5 didn't change.  This PR adds a `force` task parameter to allow forcing uploads.

Depends on #6